### PR TITLE
ci: Fix for breaking `upload-artifact`

### DIFF
--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -71,10 +71,11 @@ jobs:
           echo "TBD package v${{ steps.compose.outputs.version }}"
 
       - name: Save package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: packages
           path: package-dist
+          include-hidden-files: true
 
       - name: Summary output
         run: |


### PR DESCRIPTION
Breaking change from [upload-artifact](https://github.com/actions/upload-artifact) v4.4.0 that now requires explicit need to place `include-hidden-files: true` under `with:` block.